### PR TITLE
refactor: centralize deck building in helper

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,25 +1,30 @@
-const POKEMON = {
-  Pikachu: {
-    hp: 100,
-    moves: [
+function buildDeck(pokemonName, energyType) {
+  const moves = {
+    Pikachu: [
       { name: 'Thunderbolt', damage: 20 },
       { name: 'Quick Attack', damage: 15 }
-    ]
-  },
-  Charmander: {
-    hp: 100,
-    moves: [
+    ],
+    Charmander: [
       { name: 'Flamethrower', damage: 25 },
       { name: 'Scratch', damage: 10 }
-    ]
-  },
-  Bulbasaur: {
-    hp: 100,
-    moves: [
+    ],
+    Bulbasaur: [
       { name: 'Vine Whip', damage: 20 },
       { name: 'Tackle', damage: 15 }
     ]
-  }
+  };
+
+  return {
+    hp: 100,
+    energyType,
+    moves: moves[pokemonName]
+  };
+}
+
+const POKEMON = {
+  Pikachu: buildDeck('Pikachu', 'electric'),
+  Charmander: buildDeck('Charmander', 'fire'),
+  Bulbasaur: buildDeck('Bulbasaur', 'grass')
 };
 
 const players = [


### PR DESCRIPTION
## Summary
- refactor repeated Pokémon card setup into `buildDeck`
- generate Pikachu, Charmander, and Bulbasaur decks via helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e455b80b8833185f25a537e67026c