### PR TITLE
Implement deck mechanic and visual upgrades

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,14 @@
       <div id="pokemonChoices"></div>
     </section>
     <section id="battle" class="hidden">
+      <div id="arena">
+        <img id="p1Img" class="pokemon-img" alt="Player 1 Pokémon">
+        <img id="p2Img" class="pokemon-img" alt="Player 2 Pokémon">
+      </div>
+      <div id="deckInfo">
+        <span id="p1Deck"></span>
+        <span id="p2Deck"></span>
+      </div>
       <p id="status"></p>
       <div id="moves"></div>
     </section>

--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-function buildDeck(pokemonName, energyType) {
+function buildPokemon(pokemonName, energyType) {
   const moves = {
     Pikachu: [
       { name: 'Thunderbolt', damage: 20 },
@@ -22,14 +22,22 @@ function buildDeck(pokemonName, energyType) {
 }
 
 const POKEMON = {
-  Pikachu: buildDeck('Pikachu', 'electric'),
-  Charmander: buildDeck('Charmander', 'fire'),
-  Bulbasaur: buildDeck('Bulbasaur', 'grass')
+  Pikachu: buildPokemon('Pikachu', 'electric'),
+  Charmander: buildPokemon('Charmander', 'fire'),
+  Bulbasaur: buildPokemon('Bulbasaur', 'grass')
 };
 
+function getPokemonImage(name) {
+  return `img/pokemon/${name.toLowerCase()}.png`;
+}
+
+function generateDeck(size = 10) {
+  return Array.from({ length: size }, (_, i) => i + 1);
+}
+
 const players = [
-  { name: 'Player 1', pokemon: null, pokemonName: null },
-  { name: 'Player 2', pokemon: null, pokemonName: null }
+  { name: 'Player 1', pokemon: null, pokemonName: null, deck: [] },
+  { name: 'Player 2', pokemon: null, pokemonName: null, deck: [] }
 ];
 
 let currentPlayer = 0;
@@ -41,12 +49,23 @@ const currentPlayerSpan = document.getElementById('currentPlayer');
 const pokemonChoicesDiv = document.getElementById('pokemonChoices');
 const statusP = document.getElementById('status');
 const movesDiv = document.getElementById('moves');
+const p1Img = document.getElementById('p1Img');
+const p2Img = document.getElementById('p2Img');
+const p1DeckSpan = document.getElementById('p1Deck');
+const p2DeckSpan = document.getElementById('p2Deck');
 
 function showPokemonChoices() {
   pokemonChoicesDiv.innerHTML = '';
   Object.keys(POKEMON).forEach(name => {
     const btn = document.createElement('button');
-    btn.textContent = name;
+    btn.classList.add('pokemon-choice');
+    const img = document.createElement('img');
+    img.src = getPokemonImage(name);
+    img.alt = name;
+    btn.appendChild(img);
+    const label = document.createElement('div');
+    label.textContent = name;
+    btn.appendChild(label);
     btn.onclick = () => choosePokemon(name);
     pokemonChoicesDiv.appendChild(btn);
   });
@@ -64,8 +83,14 @@ function choosePokemon(name) {
 }
 
 function startBattle() {
+  players.forEach(player => {
+    player.deck = generateDeck();
+  });
   currentPlayer = 0;
   defendingPlayer = 1;
+  p1Img.src = getPokemonImage(players[0].pokemonName);
+  p2Img.src = getPokemonImage(players[1].pokemonName);
+  updateDeckInfo();
   setupSection.classList.add('hidden');
   battleSection.classList.remove('hidden');
   startTurn();
@@ -86,13 +111,15 @@ function startTurn(message = '') {
   const player = players[currentPlayer];
   const opponent = players[defendingPlayer];
 
-  if (player.deck && player.deck.length === 0) {
+  if (player.deck.length === 0) {
     movesDiv.innerHTML = '';
     updateStatus(`${message}${opponent.name} wins! ${player.name} has no cards left.`);
     return;
   }
 
-  updateStatus(`${message}${player.name}'s turn.`);
+  player.deck.pop();
+  updateDeckInfo();
+  updateStatus(`${message}${player.name}'s turn. ${player.deck.length} cards left in deck.`);
   renderMoves();
 }
 
@@ -115,6 +142,11 @@ function performMove(move) {
 
 function updateStatus(text) {
   statusP.innerHTML = text;
+}
+
+function updateDeckInfo() {
+  p1DeckSpan.textContent = `Player 1 Deck: ${players[0].deck.length}`;
+  p2DeckSpan.textContent = `Player 2 Deck: ${players[1].deck.length}`;
 }
 
 showPokemonChoices();

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 body {
   font-family: sans-serif;
   text-align: center;
-  background: #f0f0f0;
+  background: linear-gradient(45deg, #f5f7fa, #c3cfe2);
   margin: 0;
 }
 
@@ -21,4 +21,32 @@ button {
   margin: 0.25em;
   padding: 0.5em 1em;
   font-size: 1em;
+}
+
+.pokemon-choice {
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.pokemon-choice img {
+  width: 100px;
+  height: auto;
+  display: block;
+}
+
+#arena {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  margin-bottom: 1em;
+}
+
+.pokemon-img {
+  width: 120px;
+  height: auto;
+}
+
+#deckInfo {
+  margin-bottom: 1em;
 }


### PR DESCRIPTION
## Summary
- add player decks with card draw and loss condition when empty
- show Pokémon images in selection and battle arena with deck counters
- improve styling with gradient background and layout tweaks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e526285a0833190569c356acb4ac3