### PR TITLE
Handle missing card DB gracefully

### DIFF
--- a/script.js
+++ b/script.js
@@ -459,7 +459,13 @@ function provideHint() {
   updateStatus('Hint: End your turn.');
 }
 
-loadCardDB().then(showPokemonChoices);
+loadCardDB()
+  .then(showPokemonChoices)
+  .catch(err => {
+    console.error('Failed to load card DB', err);
+    updateStatus('Failed to load card database. Check console for details.');
+    showPokemonChoices();
+  });
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {


### PR DESCRIPTION
## Summary
- Call `showPokemonChoices()` whether card DB load succeeds or fails
- Log and surface a status message when the card DB can't be loaded

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e831dd65c83319c91707dd3b15f95