### PR TITLE
Handle missing Pokémon card in deck assembly

### DIFF
--- a/script.js
+++ b/script.js
@@ -167,6 +167,9 @@ function buildDeck(player) {
     player.active = player.hand.splice(activeIdx, 1)[0];
   } else {
     const idx = player.deck.findIndex(c => c.type === 'pokemon');
+    if (idx === -1) {
+      throw new Error('No Pokémon card found in deck. Please choose a different deck.');
+    }
     player.active = player.deck.splice(idx, 1)[0];
   }
   player.active.maxHp = player.active.hp;


### PR DESCRIPTION
## Summary
- verify buildDeck finds a Pokémon before splicing deck
- throw descriptive error when no Pokémon cards are present

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e86ae67308331ada4c3dadb147468