### PR TITLE
Add handling for bench and coin flip attack effects

### DIFF
--- a/script.js
+++ b/script.js
@@ -101,6 +101,30 @@ function applyAttack(attacker, attack, defender) {
     case 'discard_energy':
       attacker.attachedEnergy?.pop();
       break;
+    case 'bench_damage':
+      if (defender.bench && defender.bench.length > 0) {
+        const target = defender.bench[0];
+        target.hp = Math.max(target.hp - 10, 0);
+        console.log(`Bench damage dealt to ${target.name}`);
+      } else {
+        console.log('Bench damage effect: defender has no benched Pokémon.');
+      }
+      break;
+    case 'coin_flip_bonus':
+      const match = attack.effect?.match(/(\d+)\s+more damage/);
+      const bonus = match ? parseInt(match[1], 10) : 20;
+      if (Math.random() < 0.5) {
+        defender.hp = Math.max(defender.hp - bonus, 0);
+        console.log(`Coin flip success! Bonus ${bonus} damage.`);
+      } else {
+        console.log('Coin flip failed. No bonus damage.');
+      }
+      break;
+    default:
+      if (attack.effectKeyword) {
+        console.warn(`Unknown effect keyword: ${attack.effectKeyword}`);
+      }
+      break;
   }
 }
 


### PR DESCRIPTION
## Summary
- support bench damage and coin flip bonus effects in attack resolution
- log unknown attack effect keywords for easier debugging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e89454e488331882ce07d09080b2f