### PR TITLE
Cache additional assets for offline play

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,10 +1,16 @@
-const CACHE_NAME = 'pba-cache-v1';
+const CACHE_NAME = 'pba-cache-v2';
 const ASSETS = [
   './',
   './index.html',
   './style.css',
   './script.js',
-  './manifest.json'
+  './manifest.json',
+  './data/pokemon_cardDB.json',
+  './img/icons/icon-192x192.png',
+  './img/icons/icon-512x512.png',
+  './img/pokemon/bulbasaur.png',
+  './img/pokemon/charmander.png',
+  './img/pokemon/pikachu.png'
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
- expand service worker precache to include card data and images
- bump cache version for redeploy

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e8a3e9f9483319892ba04259523a9