### PR TITLE
Enable bench placement for selected Pokémon

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -115,8 +115,13 @@ function renderBench(player) {
   });
   for (let i = player.bench.length; i < 5; i++) {
     const placeholder = document.createElement('button');
-    placeholder.textContent = '(empty)';
-    placeholder.disabled = true;
+    if (selectedCardIdx !== null) {
+      placeholder.textContent = 'Place here';
+      placeholder.onclick = () => playPokemonToBench(selectedCardIdx);
+    } else {
+      placeholder.textContent = '(empty)';
+      placeholder.disabled = true;
+    }
     benchDiv.appendChild(placeholder);
   }
 }
@@ -126,6 +131,8 @@ function showCardDetails(card, idx) {
   if (selectedCardIdx === idx) {
     selectedCardIdx = null;
     cardInfoDiv.innerHTML = '';
+    benchDiv.innerHTML = '';
+    renderBench(player);
     return;
   }
   selectedCardIdx = idx;
@@ -138,6 +145,8 @@ function showCardDetails(card, idx) {
     info += `<br>Energy Type: ${card.energyType}`;
   }
   cardInfoDiv.innerHTML = info;
+  benchDiv.innerHTML = '';
+  renderBench(player);
   if (card.type === 'pokemon') {
     const benchBtn = document.createElement('button');
     benchBtn.textContent = 'Play to Bench';


### PR DESCRIPTION
## Summary
- Allow bench placeholders to accept a selected Pokémon card
- Refresh bench display when Pokémon card selection changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e9804ed2c833190e20dd106de6609