### PR TITLE
Fix persona image loading

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -50,8 +50,8 @@ export function updateDeckInfo() {
 }
 
 export function updateActiveInfo() {
-  p1Img.src = getPokemonImage(players[0].active.name);
-  p2Img.src = getPokemonImage(players[1].active.name);
+  p1Img.src = getPokemonImage(players[0].persona);
+  p2Img.src = getPokemonImage(players[1].persona);
   p1ActiveName.textContent = `${players[0].active.name} (${players[0].active.hp} HP)`;
   p2ActiveName.textContent = `${players[1].active.name} (${players[1].active.hp} HP)`;
 }


### PR DESCRIPTION
## Summary
- Load persona images instead of active Pokémon images to ensure images display correctly during battle

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e9b1f4eac8331a3d45d505f5070fd