### PR TITLE
Handle bench knockouts and add tests

### DIFF
--- a/battle.js
+++ b/battle.js
@@ -43,10 +43,27 @@ export function applyAttack(attacker, attack, defender) {
       attacker.attachedEnergy?.pop();
       break;
     case 'bench_damage':
-      if (defender.bench && defender.bench.length > 0) {
-        const target = defender.bench[0];
+      const defending = players[defendingPlayer];
+      if (defending.bench && defending.bench.length > 0) {
+        const target = defending.bench[0];
         target.hp = Math.max(target.hp - 10, 0);
         console.log(`Bench damage dealt to ${target.name}`);
+        if (target.hp === 0) {
+          defending.bench.shift();
+          const attackerPlayer = players[currentPlayer];
+          let message = `${target.name} on the bench was knocked out! `;
+          if (attackerPlayer.prizeCards.length > 0) {
+            attackerPlayer.prizeCards.pop();
+            attackerPlayer.prizesTaken++;
+            updateDeckInfo();
+            message += `${attackerPlayer.name} takes a prize (${attackerPlayer.prizesTaken}/3).`;
+            if (attackerPlayer.prizeCards.length === 0) {
+              updateStatus(message + ` ${attackerPlayer.name} wins!`);
+              break;
+            }
+          }
+          updateStatus(message);
+        }
       } else {
         console.log('Bench damage effect: defender has no benched Pokémon.');
       }

--- a/battle.test.js
+++ b/battle.test.js
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// Minimal DOM stubs so ui.js can be imported in Node
+const elements = {};
+const elementStub = () => ({
+  classList: { add() {}, remove() {} },
+  addEventListener() {},
+  appendChild() {},
+  textContent: '',
+  innerHTML: '',
+  onclick: null,
+  src: '',
+  disabled: false
+});
+
+global.document = {
+  getElementById(id) {
+    if (!elements[id]) elements[id] = elementStub();
+    return elements[id];
+  }
+};
+
+test('bench damage knockout awards prize card', async () => {
+  const battle = await import('./battle.js');
+  const { players, applyAttack } = battle;
+
+  players[0].deck = [];
+  players[0].prizeCards = ['p'];
+  players[0].prizesTaken = 0;
+  players[0].active = { name: 'Attacker', hp: 50, maxHp: 50, attachedEnergy: [] };
+
+  players[1].deck = [];
+  players[1].active = { name: 'Defender', hp: 60, maxHp: 60 };
+  players[1].bench = [{ name: 'Benched', hp: 10, maxHp: 10 }];
+
+  const attack = { name: 'Splash', damage: 0, effectKeyword: 'bench_damage', energyRequired: 0 };
+
+  applyAttack(players[0].active, attack, players[1].active);
+
+  assert.equal(players[1].bench.length, 0, 'bench Pokémon should be removed');
+  assert.equal(players[0].prizeCards.length, 0, 'attacker should take a prize card');
+  assert.equal(players[0].prizesTaken, 1, 'attacker prize count should increase');
+  assert.equal(elements['p1Prizes'].textContent, 'Score: 1/3', 'UI should update prize display');
+});
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "pba",
   "version": "1.0.0",
+  "type": "module",
   "scripts": {
-    "test": "echo 'No tests yet' && exit 0"
+    "test": "node --test"
   }
 }


### PR DESCRIPTION
## Summary
- Handle bench damage knockouts by removing the benched Pokémon, awarding prize cards, and updating status/deck info
- Enable Node's native test runner and add bench damage knockout test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688eadf9bcd88331b36acb27cc01f9c8